### PR TITLE
Moving framework dependencies to the framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,18 @@
         }
     ],
     "require": {
-        "php": ">=5.4"
+        "php": ">=5.4",
+        "silex/silex": "~1.1",
+        "symfony/browser-kit": "~2.3",
+        "symfony/console": "~2.3",
+        "symfony/css-selector": "~2.3",
+        "symfony/dom-crawler": "~2.3",
+        "symfony/finder": "~2.3",
+        "symfony/locale": "~2.3",
+        "symfony/translation": "~2.3",
+        "symfony/twig-bridge": "~2.3",
+        "doctrine/dbal": ">=2.2.0,<2.4.0-dev",
+        "knplabs/console-service-provider": "dev-master"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Testing include the core dependencies in the framework instead of the standard-distribution
